### PR TITLE
#1 Update client with call hierarchy implementation [MIG-6139]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 dependencies = [
   "jedi-language-server==0.41.1",
-  "pydantic==1.10.5",
+  "pydantic==2.10.0",
   "requests==2.32.3"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jedi-language-server==0.41.1
 pytest==7.3.1
-pydantic==1.10.5
+pydantic==2.10.0
 pytest-asyncio==0.21.1
 requests==2.32.3

--- a/src/multilspy/language_server.py
+++ b/src/multilspy/language_server.py
@@ -641,6 +641,55 @@ class LanguageServer:
 
         return multilspy_types.Hover(**response)
 
+    async def request_prepare_call_hierarchy(self, relative_file_path: str, line: int, column: int) -> List[multilspy_types.CallHierarchyItem]:
+        """
+        Raise a [textDocument/prepareCallHierarchy](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_prepareCallHierarchy) request to the Language Server
+        to prepare the call hierarchy at the given line and column in the given file. Wait for the response and return the result.
+
+        :param relative_file_path: The relative path of the file that contains the target symbol
+        :param line: The line number of the symbol
+        :param column: The column number of the symbol
+
+        :return List[multilspy_types.CallHierarchyItem]: A list of call hierarchy items
+        """
+        with self.open_file(relative_file_path):
+            response = await self.server.send.prepare_call_hierarchy(
+                {
+                    "textDocument": {
+                        "uri": pathlib.Path(os.path.join(self.repository_root_path, relative_file_path)).as_uri()
+                    },
+                    "position": {
+                        "line": line,
+                        "character": column,
+                    },
+                }
+            )
+
+        if response is None:
+            return []
+
+        assert isinstance(response, list)
+
+        return [multilspy_types.CallHierarchyItem(**item) for item in response]
+
+    async def request_incoming_calls(self, req_call_item: multilspy_types.CallHierarchyItem) -> List[multilspy_types.CallHierarchyItem]:
+        """
+        Raise a [callHierarchy/incomingCalls](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#callHierarchy_incomingCalls) request to the Language Server
+        to find the incoming calls(one depth) to the given call hierarchy item. Wait for the response and return the result.
+
+        :param req_call_item: The call hierarchy item for which incoming calls should be looked up
+
+        :return List[multilspy_types.CallHierarchyItem]: A list of call hierarchy items
+        """
+        incoming_call_response =  await self.server.send.incoming_calls(
+            {
+                "item": req_call_item
+            }
+        )
+
+        return [multilspy_types.CallHierarchyItem(**item["from"]) for item in incoming_call_response]
+
+
 @ensure_all_methods_implemented(LanguageServer)
 class SyncLanguageServer:
     """
@@ -808,5 +857,35 @@ class SyncLanguageServer:
         """
         result = asyncio.run_coroutine_threadsafe(
             self.language_server.request_hover(relative_file_path, line, column), self.loop
+        ).result()
+        return result
+
+    def request_prepare_call_hierarchy(self, relative_file_path: str, line: int, column: int) -> List[multilspy_types.CallHierarchyItem]:
+        """
+        Raise a [textDocument/prepareCallHierarchy](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_prepareCallHierarchy) request to the Language Server
+        to prepare the call hierarchy at the given line and column in the given file. Wait for the response and return the result.
+
+        :param relative_file_path: The relative path of the file that contains the target symbol
+        :param line: The line number of the symbol
+        :param column: The column number of the symbol
+
+        :return List[multilspy_types.CallHierarchyItem]: A list of call hierarchy items
+        """
+        result = asyncio.run_coroutine_threadsafe(
+            self.language_server.request_prepare_call_hierarchy(relative_file_path, line, column), self.loop
+        ).result()
+        return result
+
+    def request_incoming_calls(self, req_call_item: multilspy_types.CallHierarchyItem) -> List[multilspy_types.CallHierarchyItem]:
+        """
+        Raise a [callHierarchy/incomingCalls](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#callHierarchy_incomingCalls) request to the Language Server
+        to find the incoming calls(one depth) to the given call hierarchy item. Wait for the response and return the result.
+
+        :param req_call_item: The call hierarchy item for which incoming calls should be looked up
+
+        :return List[multilspy_types.CallHierarchyItem]: A list of call hierarchy items
+        """
+        result = asyncio.run_coroutine_threadsafe(
+            self.language_server.request_incoming_calls(req_call_item), self.loop
         ).result()
         return result

--- a/src/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
+++ b/src/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
@@ -283,7 +283,7 @@ class EclipseJDTLS(LanguageServer):
             {"name": "JavaSE-17", "path": "static/vscode-java/extension/jre/17.0.8.1-linux-x86_64", "default": True}
         ]
         d["initializationOptions"]["settings"]["java"]["configuration"]["runtimes"] = [
-            {"name": "JavaSE-17", "path": self.runtime_dependency_paths.jre_home_path, "default": True}
+            {"name": "JavaSE-17", "path": self.runtime_dependency_paths.jre_home_path}
         ]
 
         for runtime in d["initializationOptions"]["settings"]["java"]["configuration"]["runtimes"]:

--- a/src/multilspy/language_servers/eclipse_jdtls/runtime_dependencies.json
+++ b/src/multilspy/language_servers/eclipse_jdtls/runtime_dependencies.json
@@ -14,13 +14,13 @@
             "relative_extraction_path": "vscode-java"
         },
         "osx-arm64": {
-            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@darwin-x64-1.23.0.vsix",
+            "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.38.0/java-darwin-arm64-1.38.0-403.vsix",
             "archiveType": "zip",
             "relative_extraction_path": "vscode-java",
-            "jre_home_path": "extension/jre/17.0.8.1-macosx-x86_64",
-            "jre_path": "extension/jre/17.0.8.1-macosx-x86_64/bin/java",
-            "lombok_jar_path": "extension/lombok/lombok-1.18.30.jar",
-            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.6.500.v20230717-2134.jar",
+            "jre_home_path": "extension/jre/17.0.13-macosx-aarch64",
+            "jre_path": "extension/jre/17.0.13-macosx-aarch64/bin/java",
+            "lombok_jar_path": "extension/lombok/lombok-1.18.34.jar",
+            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.6.900.v20240613-2009.jar",
             "jdtls_readonly_config_path": "extension/server/config_mac_arm"
         },
         "linux-arm64": {

--- a/src/multilspy/multilspy_types.py
+++ b/src/multilspy/multilspy_types.py
@@ -281,3 +281,24 @@ class Hover(TypedDict):
     range: NotRequired["Range"]
     """ An optional range inside the text document that is used to
     visualize the hover, e.g. by changing the background color. """
+
+class CallHierarchyItem(TypedDict):
+    """Represents a call hierarchy item."""
+
+    name: str
+    """ The name of this item. """
+    kind: SymbolKind
+    """ The kind of this item. """
+    tags: NotRequired[List[SymbolTag]]
+    """ Tags for this item. """
+    detail: NotRequired[str]
+    """ More detail for this item, e.g the package and class name of the symbol. """
+    uri: DocumentUri
+    """ The resource identifier of this item. """
+    range: Range
+    """ The range enclosing this symbol not including leading/trailing whitespace but everything else
+    like comments. This information is typically used to determine if the clients cursor is
+    inside the symbol to reveal in the symbol in the UI. """
+    selectionRange: Range
+    """ The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
+    Must be contained by the `range`. """

--- a/tests/multilspy/test_multilspy_java.py
+++ b/tests/multilspy/test_multilspy_java.py
@@ -489,6 +489,6 @@ async def test_multilspy_java_example_repo_prepare_and_incoming_call_hierarchy()
 
             # recursively get one more depth in incoming call hierarchy
             incoming_call_dep_two = await lsp.request_incoming_calls(incoming_call_dep_one[0])
-            print(incoming_call_dep_two)
+
             assert len(incoming_call_dep_two) == 1
             assert incoming_call_dep_two[0]['name'] == 'flushToClickHouse(ClickHouseSinkRequest, CompletableFuture<Boolean>) : void'


### PR DESCRIPTION
Background
We would like to resolve the full call stack(with multiple depth) from a method call in Java application. This pr adds related client implementations and tested on Java code. and also fixed some issues when running client with Eclipse LSP on macOs darwin arm64.

This PR:
- Fixed Eclipse LSP not able to run properly on macOs darwin arm64 issue.
- Add client implementations of "prepare call hierarchy" as described here https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#textDocument_prepareCallHierarchy
- Add client implementation of "incoming calls " as described here https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#callHierarchy_incomingCalls